### PR TITLE
Correct some problems with specification of Postgresql servers

### DIFF
--- a/evolutions/evolutions.py
+++ b/evolutions/evolutions.py
@@ -83,12 +83,13 @@ def get_connection(url, user, pw):
         cmd = ['mysql', '-u', user, '--password='+pw, db_name]
         param = '%s'
     elif db_type == 'postgresql':
-        import psycopg2
+        import psycopg2, os
         port = port or '5432'; # String because that's what match would have yielded
         conn = psycopg2.connect(user=user, password=pw,
                                 host=host, port=port, database=db_name)
         conn.set_session(autocommit=False)
-        cmd = ['psql', '-h', host or 'localhost', '-U', user, db_name]
+        os.environ['PGPASSWORD'] = pw # Password via env ins
+        cmd = ['psql', '-h', host or 'localhost', '-p', port, '-U', user, db_name]
         param = '%s'
     elif db_type == 'sqlite':
         import sqlite3

--- a/evolutions/evolutions.py
+++ b/evolutions/evolutions.py
@@ -86,7 +86,7 @@ def get_connection(url, user, pw):
         conn = psycopg2.connect(user=user, password=pw,
                                 host=host, port=port, database=db_name)
         conn.set_session(autocommit=False)
-        cmd = ['psql', '-h', 'localhost', '-U', user, db_name]
+        cmd = ['psql', '-h', host or 'localhost', '-U', user, db_name]
         param = '%s'
     elif db_type == 'sqlite':
         import sqlite3

--- a/evolutions/evolutions.py
+++ b/evolutions/evolutions.py
@@ -61,12 +61,12 @@ def read_textfile(fname):
 
 # Return DBConn wrapping DB-API2 conn (https://python.org/dev/peps/pep-0249/)
 def get_connection(url, user, pw):
-    url_re = re.compile(r'([^:]+)://([^:]+):([0-9]+)/(.+)')
+    url_re = re.compile(r'([^:]+)://([^:]+)(:([0-9]+))?/(.+)')
     file_re = re.compile(r'([^:]+):(/.+)')
     match = url_re.match(url)
     if match:
         db_type, host, port, db_name = (match.group(1), match.group(2),
-                                        match.group(3), match.group(4))
+                                        match.group(4), match.group(5))
     else:
         match = file_re.match(url)
         if match:
@@ -76,6 +76,7 @@ def get_connection(url, user, pw):
             raise Exception("Unrecognized DB URL format: '" + url + "'")
     if db_type == 'mysql':
         import mysql.connector
+        port = port or '3306'; # String because that's what match would have yielded
         conn = mysql.connector.connect(user=user, password=pw,
                                        host=host, port=port, database=db_name,
                                        charset='utf8', autocommit=False)
@@ -83,6 +84,7 @@ def get_connection(url, user, pw):
         param = '%s'
     elif db_type == 'postgresql':
         import psycopg2
+        port = port or '5432'; # String because that's what match would have yielded
         conn = psycopg2.connect(user=user, password=pw,
                                 host=host, port=port, database=db_name)
         conn.set_session(autocommit=False)


### PR DESCRIPTION
Hello:

There were a few issues associated with the specification of Postgresql servers.  Some were just inconvenient, but at least a couple were bugs.  One of the "inconvenience"  changes (the port in a URL being optional) also helps users of MySQL.

I believe these commits address these issues.

Thanks...Andrew